### PR TITLE
📝doc: Fix syntax error in api.ts example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Create `api.ts` in the project root:
 
 ```ts
 export default () => new Elysia()
-  .get('/hello', () => ({ message: 'Hello world!' })
+  .get('/hello', () => ({ message: 'Hello world!' }))
 ```
 
 Use in Vue app:


### PR DESCRIPTION
fix a little bit syntax error in README